### PR TITLE
Store PSK as a VPN secret 

### DIFF
--- a/auth-dialog/main.c
+++ b/auth-dialog/main.c
@@ -378,6 +378,8 @@ get_existing_passwords (GHashTable *vpn_data,
 			*out_psk = g_strdup (g_hash_table_lookup (existing_secrets, NM_L2TP_KEY_IPSEC_PSK));
 			if (!*out_psk)
 				*out_psk = keyring_lookup_secret (vpn_uuid, NM_L2TP_KEY_IPSEC_PSK);
+			if (!*out_psk) /* For legacy purposes, the PSK can also be specified as a non-secret */
+				*out_psk = g_strdup (g_hash_table_lookup (vpn_data, NM_L2TP_KEY_IPSEC_PSK));
 		}
 	}
 

--- a/auth-dialog/main.c
+++ b/auth-dialog/main.c
@@ -422,17 +422,20 @@ get_passwords_required (GHashTable *data,
 			*out_need_password = TRUE;
 	}
 
-	authtype = g_hash_table_lookup (data, NM_L2TP_KEY_MACHINE_AUTH_TYPE);
-	if (nm_streq0 (authtype, NM_L2TP_AUTHTYPE_TLS)) {
-		/* Encrypted PKCS#12 certificate or private key password */
-		val = g_hash_table_lookup (data, NM_L2TP_KEY_MACHINE_KEY);
-		if (val)
-			crypto_file_format (val, out_need_machine_certpass, NULL);
-	} else { /* NM_L2TP_AUTHTYPE_PSK */
-		flags = NM_SETTING_SECRET_FLAG_NONE;
-		nm_vpn_service_plugin_get_secret_flags (data, NM_L2TP_KEY_IPSEC_PSK, &flags);
-		if (!(flags & NM_SETTING_SECRET_FLAG_NOT_REQUIRED))
-			*out_need_psk = TRUE;
+	val = g_hash_table_lookup (data, NM_L2TP_KEY_IPSEC_ENABLE);
+	if(nm_streq0 (val, "yes")) {
+		authtype = g_hash_table_lookup (data, NM_L2TP_KEY_MACHINE_AUTH_TYPE);
+		if (nm_streq0 (authtype, NM_L2TP_AUTHTYPE_TLS)) {
+			/* Encrypted PKCS#12 certificate or private key password */
+			val = g_hash_table_lookup (data, NM_L2TP_KEY_MACHINE_KEY);
+			if (val)
+				crypto_file_format (val, out_need_machine_certpass, NULL);
+		} else { /* NM_L2TP_AUTHTYPE_PSK */
+			flags = NM_SETTING_SECRET_FLAG_NONE;
+			nm_vpn_service_plugin_get_secret_flags (data, NM_L2TP_KEY_IPSEC_PSK, &flags);
+			if (!(flags & NM_SETTING_SECRET_FLAG_NOT_REQUIRED))
+				*out_need_psk = TRUE;
+		}
 	}
 
 	return NULL;

--- a/properties/import-export.c
+++ b/properties/import-export.c
@@ -43,7 +43,6 @@ mtu=1200 (int)
 
 ipsec-enabled=true (bool)
 ipsec-gateway-id=192.168.0.1 (str)
-ipsec-psk=my_psk (str)
 ipsec-forceencaps=true (bool)
 
 [ipv4]
@@ -96,7 +95,6 @@ static VpnImportExportProperty vpn_properties[] = {
 	{ NM_L2TP_KEY_IPSEC_ENABLE,             G_TYPE_BOOLEAN, FALSE },
 	{ NM_L2TP_KEY_IPSEC_REMOTE_ID,          G_TYPE_STRING, FALSE },
 	{ NM_L2TP_KEY_IPSEC_GATEWAY_ID,         G_TYPE_STRING, FALSE },
-	{ NM_L2TP_KEY_IPSEC_PSK,                G_TYPE_STRING, FALSE },
 	{ NM_L2TP_KEY_IPSEC_IKE,                G_TYPE_STRING, FALSE },
 	{ NM_L2TP_KEY_IPSEC_ESP,                G_TYPE_STRING, FALSE },
 	{ NM_L2TP_KEY_IPSEC_IKELIFETIME,        G_TYPE_UINT, FALSE },
@@ -107,6 +105,7 @@ static VpnImportExportProperty vpn_properties[] = {
 	{ NM_L2TP_KEY_IPSEC_PFS,                G_TYPE_BOOLEAN, FALSE },
 	/* { NM_L2TP_KEY_PASSWORD"-flags",         G_TYPE_UINT, FALSE },*/
 	/* { NM_L2TP_KEY_USER_CERTPASS"-flags",    G_TYPE_UINT, FALSE },*/
+	/* { NM_L2TP_KEY_IPSEC_PSK"-flags",        G_TYPE_UINT, FALSE },*/
 	/* { NM_L2TP_KEY_MACHINE_CERTPASS"-flags", G_TYPE_UINT, FALSE },*/
 	{ NULL }
 };

--- a/properties/ipsec-dialog.c
+++ b/properties/ipsec-dialog.c
@@ -11,6 +11,7 @@
 #include "nm-l2tp-editor.h"
 
 #include "nm-utils/nm-shared-utils.h"
+#include "nm-utils/nm-secret-utils.h"
 #include "shared/nm-l2tp-crypto-openssl.h"
 #include "shared/utils.h"
 
@@ -69,7 +70,7 @@ ipsec_dialog_new_hash_from_connection (NMConnection *connection,
 	nm_setting_vpn_foreach_data_item (s_vpn, hash_copy_value, hash);
 
 	/* IPSEC PSK is special */
-	secret = nm_setting_vpn_get_secret (s_vpn, NM_L2TP_KEY_IPSEC_PSK);
+	secret = nm_setting_vpn_get_secret_or_legacy_data_item (s_vpn, NM_L2TP_KEY_IPSEC_PSK);
 	if (secret) {
 		g_hash_table_insert (hash,
 		                     g_strdup (NM_L2TP_KEY_IPSEC_PSK),

--- a/properties/nm-l2tp-editor.c
+++ b/properties/nm-l2tp-editor.c
@@ -727,10 +727,15 @@ copy_hash_pair (gpointer key, gpointer data, gpointer user_data)
 	g_return_if_fail (value && value[0]);
 
 	/* IPsec PSK and certificate password is a secret, not a data item */
-	if (!strcmp (key, NM_L2TP_KEY_IPSEC_PSK) || !strcmp (key, NM_L2TP_KEY_MACHINE_CERTPASS))
+	if (!strcmp (key, NM_L2TP_KEY_IPSEC_PSK)) {
+		/* Migrate legacy non-secret PSK data items to VPN secret */
+		nm_setting_vpn_remove_data_item (s_vpn, (const char *) key);
 		nm_setting_vpn_add_secret (s_vpn, (const char *) key, value);
-	else
+	} else if (!strcmp (key, NM_L2TP_KEY_MACHINE_CERTPASS)) {
+		nm_setting_vpn_add_secret (s_vpn, (const char *) key, value);
+	} else {
 		nm_setting_vpn_add_data_item (s_vpn, (const char *) key, value);
+	}
 }
 
 static char *

--- a/properties/nm-l2tp-editor.c
+++ b/properties/nm-l2tp-editor.c
@@ -726,8 +726,8 @@ copy_hash_pair (gpointer key, gpointer data, gpointer user_data)
 
 	g_return_if_fail (value && value[0]);
 
-	/* IPsec certificate password is a secret, not a data item */
-	if (!strcmp (key, NM_L2TP_KEY_MACHINE_CERTPASS))
+	/* IPsec PSK and certificate password is a secret, not a data item */
+	if (!strcmp (key, NM_L2TP_KEY_IPSEC_PSK) || !strcmp (key, NM_L2TP_KEY_MACHINE_CERTPASS))
 		nm_setting_vpn_add_secret (s_vpn, (const char *) key, value);
 	else
 		nm_setting_vpn_add_data_item (s_vpn, (const char *) key, value);

--- a/shared/nm-utils/nm-secret-utils.h
+++ b/shared/nm-utils/nm-secret-utils.h
@@ -133,4 +133,14 @@ GBytes *nm_secret_buf_to_gbytes_take (NMSecretBuf *secret, gssize actual_len);
 
 /*****************************************************************************/
 
+static inline const char *nm_setting_vpn_get_secret_or_legacy_data_item
+	(NMSettingVpn *setting, const char *key) {
+	const char *value = nm_setting_vpn_get_secret (setting, key);
+	if (!value)
+		value = nm_setting_vpn_get_data_item (setting, key);
+	return value;
+}
+
+/*****************************************************************************/
+
 #endif /* __NM_SECRET_UTILS_H__ */

--- a/src/nm-l2tp-service.c
+++ b/src/nm-l2tp-service.c
@@ -1888,27 +1888,30 @@ real_need_secrets (NMVpnServicePlugin *plugin,
 			need_secrets = FALSE;
 	}
 
-	value = nm_setting_vpn_get_data_item (s_vpn, NM_L2TP_KEY_MACHINE_AUTH_TYPE);
-	if (!need_secrets && nm_streq0 (value, NM_L2TP_AUTHTYPE_TLS)) {
-		/* Check if machine certificate or machine private key need a password */
-		value = nm_setting_vpn_get_data_item (s_vpn, NM_L2TP_KEY_MACHINE_KEY);
-		crypto_file_format (value, &need_secrets, NULL);
+	value = nm_setting_vpn_get_data_item (s_vpn, NM_L2TP_KEY_IPSEC_ENABLE);
+	if(nm_streq0 (value, "yes")) {
+		value = nm_setting_vpn_get_data_item (s_vpn, NM_L2TP_KEY_MACHINE_AUTH_TYPE);
+		if (!need_secrets && nm_streq0 (value, NM_L2TP_AUTHTYPE_TLS)) {
+			/* Check if machine certificate or machine private key need a password */
+			value = nm_setting_vpn_get_data_item (s_vpn, NM_L2TP_KEY_MACHINE_KEY);
+			crypto_file_format (value, &need_secrets, NULL);
 
-		/* Don't need the password if we already have one */
-		if (need_secrets && nm_setting_vpn_get_secret (NM_SETTING_VPN (s_vpn), NM_L2TP_KEY_MACHINE_CERTPASS)) {
-				need_secrets = FALSE;
-		}
-	} else if (!need_secrets) { /* NM_L2TP_AUTHTYPE_PSK */
-		/* Check if need PSK */
-		nm_setting_get_secret_flags (NM_SETTING (s_vpn), NM_L2TP_KEY_IPSEC_PSK, &flags, NULL);
+			/* Don't need the password if we already have one */
+			if (need_secrets && nm_setting_vpn_get_secret (NM_SETTING_VPN (s_vpn), NM_L2TP_KEY_MACHINE_CERTPASS)) {
+					need_secrets = FALSE;
+			}
+		} else if (!need_secrets) { /* NM_L2TP_AUTHTYPE_PSK */
+			/* Check if need PSK */
+			nm_setting_get_secret_flags (NM_SETTING (s_vpn), NM_L2TP_KEY_IPSEC_PSK, &flags, NULL);
 
-		/* Need the PSK if user specified it is required */
-		if (!(flags & NM_SETTING_SECRET_FLAG_NOT_REQUIRED))
-			need_secrets = TRUE;
+			/* Need the PSK if user specified it is required */
+			if (!(flags & NM_SETTING_SECRET_FLAG_NOT_REQUIRED))
+				need_secrets = TRUE;
 
-		/* Don't need the PSK if we already have one */
-		if (need_secrets && nm_setting_vpn_get_secret_or_legacy_data_item (NM_SETTING_VPN (s_vpn), NM_L2TP_KEY_IPSEC_PSK)) {
-				need_secrets = FALSE;
+			/* Don't need the PSK if we already have one */
+			if (need_secrets && nm_setting_vpn_get_secret_or_legacy_data_item (NM_SETTING_VPN (s_vpn), NM_L2TP_KEY_IPSEC_PSK)) {
+					need_secrets = FALSE;
+			}
 		}
 	}
 

--- a/src/nm-l2tp-service.c
+++ b/src/nm-l2tp-service.c
@@ -180,7 +180,6 @@ static const ValidProperty valid_properties[] = {
 	{ NM_L2TP_KEY_IPSEC_ENABLE,             G_TYPE_BOOLEAN, FALSE },
 	{ NM_L2TP_KEY_IPSEC_REMOTE_ID,          G_TYPE_STRING, FALSE },
 	{ NM_L2TP_KEY_IPSEC_GATEWAY_ID,         G_TYPE_STRING, FALSE },
-	{ NM_L2TP_KEY_IPSEC_PSK,                G_TYPE_STRING, FALSE },
 	{ NM_L2TP_KEY_IPSEC_IKE,                G_TYPE_STRING, FALSE },
 	{ NM_L2TP_KEY_IPSEC_ESP,                G_TYPE_STRING, FALSE },
 	{ NM_L2TP_KEY_IPSEC_IKELIFETIME,        G_TYPE_UINT, FALSE },
@@ -191,6 +190,7 @@ static const ValidProperty valid_properties[] = {
 	{ NM_L2TP_KEY_IPSEC_PFS,                G_TYPE_BOOLEAN, FALSE },
 	{ NM_L2TP_KEY_PASSWORD"-flags",         G_TYPE_UINT, FALSE },
 	{ NM_L2TP_KEY_USER_CERTPASS"-flags",    G_TYPE_UINT, FALSE },
+	{ NM_L2TP_KEY_IPSEC_PSK"-flags",        G_TYPE_UINT, FALSE },
 	{ NM_L2TP_KEY_MACHINE_CERTPASS"-flags", G_TYPE_UINT, FALSE },
 	{ KDE_PLASMA_L2TP_KEY_USE_CERT,         G_TYPE_UINT, FALSE },
 	{ KDE_PLASMA_L2TP_KEY_CERT_CA,          G_TYPE_STRING, FALSE },
@@ -202,6 +202,7 @@ static const ValidProperty valid_properties[] = {
 static ValidProperty valid_secrets[] = {
 	{ NM_L2TP_KEY_PASSWORD,                 G_TYPE_STRING, FALSE },
 	{ NM_L2TP_KEY_USER_CERTPASS,            G_TYPE_STRING, FALSE },
+	{ NM_L2TP_KEY_IPSEC_PSK,                G_TYPE_STRING, FALSE },
  	{ NM_L2TP_KEY_MACHINE_CERTPASS,         G_TYPE_STRING, FALSE },
  	{ NM_L2TP_KEY_NOSECRET,                 G_TYPE_STRING, FALSE },
 	{ NULL }
@@ -721,7 +722,7 @@ nm_l2tp_config_write (NML2tpPlugin *plugin,
 					}
 				}
 
-				value = nm_setting_vpn_get_data_item (s_vpn, NM_L2TP_KEY_IPSEC_PSK);
+				value = nm_setting_vpn_get_secret (s_vpn, NM_L2TP_KEY_IPSEC_PSK);
 				if (!value) value="";
 
 				if (g_str_has_prefix (value, "0s")) {
@@ -1884,14 +1885,26 @@ real_need_secrets (NMVpnServicePlugin *plugin,
 			need_secrets = FALSE;
 	}
 
-	/* Check if machine certificate or machine private key need a password */
 	value = nm_setting_vpn_get_data_item (s_vpn, NM_L2TP_KEY_MACHINE_AUTH_TYPE);
 	if (!need_secrets && nm_streq0 (value, NM_L2TP_AUTHTYPE_TLS)) {
+		/* Check if machine certificate or machine private key need a password */
 		value = nm_setting_vpn_get_data_item (s_vpn, NM_L2TP_KEY_MACHINE_KEY);
 		crypto_file_format (value, &need_secrets, NULL);
 
 		/* Don't need the password if we already have one */
 		if (need_secrets && nm_setting_vpn_get_secret (NM_SETTING_VPN (s_vpn), NM_L2TP_KEY_MACHINE_CERTPASS)) {
+				need_secrets = FALSE;
+		}
+	} else if (!need_secrets) { /* NM_L2TP_AUTHTYPE_PSK */
+		/* Check if need PSK */
+		nm_setting_get_secret_flags (NM_SETTING (s_vpn), NM_L2TP_KEY_IPSEC_PSK, &flags, NULL);
+
+		/* Need the PSK if user specified it is required */
+		if (!(flags & NM_SETTING_SECRET_FLAG_NOT_REQUIRED))
+			need_secrets = TRUE;
+
+		/* Don't need the PSK if we already have one */
+		if (need_secrets && nm_setting_vpn_get_secret (NM_SETTING_VPN (s_vpn), NM_L2TP_KEY_IPSEC_PSK)) {
 				need_secrets = FALSE;
 		}
 	}

--- a/src/nm-l2tp-service.c
+++ b/src/nm-l2tp-service.c
@@ -39,6 +39,7 @@
 #include "nm-ppp-status.h"
 #include "nm-l2tp-pppd-service-dbus.h"
 #include "nm-utils/nm-shared-utils.h"
+#include "nm-utils/nm-secret-utils.h"
 #include "nm-utils/nm-vpn-plugin-macros.h"
 #include "shared/utils.h"
 #include "nm-l2tp-crypto-nss.h"
@@ -180,6 +181,8 @@ static const ValidProperty valid_properties[] = {
 	{ NM_L2TP_KEY_IPSEC_ENABLE,             G_TYPE_BOOLEAN, FALSE },
 	{ NM_L2TP_KEY_IPSEC_REMOTE_ID,          G_TYPE_STRING, FALSE },
 	{ NM_L2TP_KEY_IPSEC_GATEWAY_ID,         G_TYPE_STRING, FALSE },
+	/* For legacy purposes, the PSK can also be specified as a non-secret */
+	{ NM_L2TP_KEY_IPSEC_PSK,                G_TYPE_STRING, FALSE },
 	{ NM_L2TP_KEY_IPSEC_IKE,                G_TYPE_STRING, FALSE },
 	{ NM_L2TP_KEY_IPSEC_ESP,                G_TYPE_STRING, FALSE },
 	{ NM_L2TP_KEY_IPSEC_IKELIFETIME,        G_TYPE_UINT, FALSE },
@@ -722,7 +725,7 @@ nm_l2tp_config_write (NML2tpPlugin *plugin,
 					}
 				}
 
-				value = nm_setting_vpn_get_secret (s_vpn, NM_L2TP_KEY_IPSEC_PSK);
+				value = nm_setting_vpn_get_secret_or_legacy_data_item (s_vpn, NM_L2TP_KEY_IPSEC_PSK);
 				if (!value) value="";
 
 				if (g_str_has_prefix (value, "0s")) {
@@ -1904,7 +1907,7 @@ real_need_secrets (NMVpnServicePlugin *plugin,
 			need_secrets = TRUE;
 
 		/* Don't need the PSK if we already have one */
-		if (need_secrets && nm_setting_vpn_get_secret (NM_SETTING_VPN (s_vpn), NM_L2TP_KEY_IPSEC_PSK)) {
+		if (need_secrets && nm_setting_vpn_get_secret_or_legacy_data_item (NM_SETTING_VPN (s_vpn), NM_L2TP_KEY_IPSEC_PSK)) {
 				need_secrets = FALSE;
 		}
 	}


### PR DESCRIPTION
Issue: nm-l2tp#78

Compatibility with both secret and non-secret PSK.

Check for machine auth secrets only if NM_L2TP_KEY_IPSEC_ENABLE=yes.
Otherwise the code is fragile and may end up asking for secrets which are not
needed. This happened with the recent 'PSK as NetworkManager-secret' changes,
where if the PSK was set to "Ask for this password every time" but the IPSec
tunnel was disabled, the user was still prompted for the PSK when connecting